### PR TITLE
Melkehitys-1020

### DIFF
--- a/src/api-client.js
+++ b/src/api-client.js
@@ -45,7 +45,7 @@ export function createApiClient({url, username, password, userAgent = 'Record im
 		getBlobContent, deleteBlobContent,
 		getProfile, modifyProfile, queryProfiles, deleteProfile,
 		setTransformationDone, setTransformationFailed, setRecordProcessed,
-		transformedRecordFailed, setAborted, updateState
+		transformedRecord, setAborted, updateState
 	};
 
 	async function createBlob({blob, type, profile}) {
@@ -190,11 +190,11 @@ export function createApiClient({url, username, password, userAgent = 'Record im
 		throw new ApiError(response.status);
 	}
 
-	async function transformedRecordFailed({id, record}) {
+	async function transformedRecord({id, record = null}) {
 		await updateBlobMetadata({
 			id,
 			payload: {
-				op: BLOB_UPDATE_OPERATIONS.transformedRecordFailed,
+				op: BLOB_UPDATE_OPERATIONS.transformedRecord,
 				transformedRecord: record
 			}
 		});
@@ -209,12 +209,11 @@ export function createApiClient({url, username, password, userAgent = 'Record im
 		});
 	}
 
-	async function setTransformationDone({id, numberOfRecords}) {
+	async function setTransformationDone({id}) {
 		await updateBlobMetadata({
 			id,
 			payload: {
-				op: BLOB_UPDATE_OPERATIONS.transformationDone,
-				numberOfRecords
+				op: BLOB_UPDATE_OPERATIONS.transformationDone
 			}
 		});
 	}

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -190,12 +190,12 @@ export function createApiClient({url, username, password, userAgent = 'Record im
 		throw new ApiError(response.status);
 	}
 
-	async function transformedRecord({id, record = null}) {
+	async function transformedRecord({id, failedRecord = undefined}) {
 		await updateBlobMetadata({
 			id,
 			payload: {
 				op: BLOB_UPDATE_OPERATIONS.transformedRecord,
-				transformedRecord: record
+				error: failedRecord
 			}
 		});
 	}

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -44,7 +44,7 @@ export function createApiClient({url, username, password, userAgent = 'Record im
 		getBlobs, createBlob, getBlobMetadata, deleteBlob,
 		getBlobContent, deleteBlobContent,
 		getProfile, modifyProfile, queryProfiles, deleteProfile,
-		setTransformationDone, setTransformationFailed, setRecordProcessed,
+		setTransformationFailed, setRecordProcessed,
 		transformedRecord, setAborted, updateState
 	};
 
@@ -205,15 +205,6 @@ export function createApiClient({url, username, password, userAgent = 'Record im
 			id,
 			payload: {
 				op: BLOB_UPDATE_OPERATIONS.abort
-			}
-		});
-	}
-
-	async function setTransformationDone({id}) {
-		await updateBlobMetadata({
-			id,
-			payload: {
-				op: BLOB_UPDATE_OPERATIONS.transformationDone
 			}
 		});
 	}

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -44,7 +44,8 @@ export function createApiClient({url, username, password, userAgent = 'Record im
 		getBlobs, createBlob, getBlobMetadata, deleteBlob,
 		getBlobContent, deleteBlobContent,
 		getProfile, modifyProfile, queryProfiles, deleteProfile,
-		setTransformationDone, setTransformationFailed, setRecordProcessed, transformedRecordFailed, setAborted, updateState
+		setTransformationDone, setTransformationFailed, setRecordProcessed,
+		transformedRecordFailed, setAborted, updateState
 	};
 
 	async function createBlob({blob, type, profile}) {

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -190,12 +190,12 @@ export function createApiClient({url, username, password, userAgent = 'Record im
 		throw new ApiError(response.status);
 	}
 
-	async function transformedRecord({id, failedRecord = undefined}) {
+	async function transformedRecord({id, error = undefined}) {
 		await updateBlobMetadata({
 			id,
 			payload: {
 				op: BLOB_UPDATE_OPERATIONS.transformedRecord,
-				error: failedRecord
+				error
 			}
 		});
 	}

--- a/src/constants.js
+++ b/src/constants.js
@@ -37,7 +37,7 @@ export const BLOB_STATE = {
 
 export const BLOB_UPDATE_OPERATIONS = {
 	abort: 'abort',
-	transformedRecordFailed: 'transformedRecordFailed',
+	transformedRecord: 'transformedRecord',
 	transformationStarted: 'transformationStarted',
 	transformationDone: 'transformationDone',
 	transformationFailed: 'transformationFailed',

--- a/src/constants.js
+++ b/src/constants.js
@@ -38,7 +38,6 @@ export const BLOB_STATE = {
 export const BLOB_UPDATE_OPERATIONS = {
 	abort: 'abort',
 	transformedRecord: 'transformedRecord',
-	transformationStarted: 'transformationStarted',
 	transformationFailed: 'transformationFailed',
 	recordProcessed: 'recordProcessed',
 	updateState: 'updateState'

--- a/src/constants.js
+++ b/src/constants.js
@@ -39,7 +39,6 @@ export const BLOB_UPDATE_OPERATIONS = {
 	abort: 'abort',
 	transformedRecord: 'transformedRecord',
 	transformationStarted: 'transformationStarted',
-	transformationDone: 'transformationDone',
 	transformationFailed: 'transformationFailed',
 	recordProcessed: 'recordProcessed',
 	updateState: 'updateState'

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -66,7 +66,10 @@ export default async ({name, yargsOptions = [], callback}) => {
 
 	await new Promise(resolve => {
 		TransformClient
-			.on('end', resolve())
+			.on('end', () => {
+				console.log('ending');
+				resolve();
+			})
 			.on('error', errorEvent)
 			.on('record', recordEvent);
 	});

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -33,8 +33,13 @@ import fs from 'fs';
 import yargs from 'yargs';
 import ora from 'ora';
 import path from 'path';
+import {Utils} from '@natlibfi/melinda-commons';
+
+const {createLogger} = Utils;
 
 export default async ({name, yargsOptions = [], callback}) => {
+	const logger = createLogger();
+
 	const args = yargs
 		.scriptName(name)
 		.command('$0 <file>', '', yargs => {
@@ -49,7 +54,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 		.parse();
 
 	if (!fs.existsSync(args.file)) {
-		console.error(`File ${args.file} does not exist`);
+		logger.log('error', `File ${args.file} does not exist`);
 		process.exit(-1);
 	}
 
@@ -61,6 +66,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 	};
 
 	await new Promise((resolve, reject) => {
+		logger.log('debug', args);
 		const TransformEmitter = callback(options);
 		const pendingPromises = [];
 		let counter = 0;
@@ -102,6 +108,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 						fs.writeFileSync(file, JSON.stringify(record, undefined, 2));
 					} else {
 						console.log(JSON.stringify(record, undefined, 2));
+						counter++;
 					}
 				}
 			});

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -60,11 +60,10 @@ export default async ({name, yargsOptions = [], callback}) => {
 
 	const spinner = ora(`Transforming${args.validate ? ' and validating' : ''}${args.fix ? ' and fixing' : ''} records`).start();
 
-	const stream =fs.createReadStream(args.file);
+	const stream = fs.createReadStream(args.file);
 
-	console.log('debug', args);
 	await new Promise((resolve, reject) => {
-		const TransformEmitter = callback(spinner, args);
+		const TransformEmitter = callback(stream, args);
 		const pendingPromises = [];
 		let counter = 0;
 

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -66,7 +66,10 @@ export default async ({name, yargsOptions = [], callback}) => {
 
 	await new Promise(resolve => {
 		TransformClient
-			.on('end', () => resolve(true))
+			.on('end', () => {
+				console.log('info', 'ending');
+				resolve(true);
+			})
 			.on('error', errorEvent)
 			.on('record', recordEvent);
 	});

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -82,7 +82,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 
 	let records = succesRecordArray;
 	if (!args.recordsOnly && failedRecordsArray.length > 0) {
-		records.join(failedRecordsArray);
+		records = [...records, ...failedRecordsArray];
 	}
 
 	Promise.all(records).then(handleOutput(records));

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -68,6 +68,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 		TransformEmitter
 			.on('end', async () => {
 				Promise.all(pendingPromises);
+				spinner.succeed();
 				resolve();
 			})
 			.on('error', err => {
@@ -106,6 +107,4 @@ export default async ({name, yargsOptions = [], callback}) => {
 				}
 			});
 	});
-
-	spinner.succeed();
 };

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -66,10 +66,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 
 	await new Promise(resolve => {
 		TransformClient
-			.on('end', () => {
-				console.log('ending');
-				resolve();
-			})
+			.on('end', () => resolve())
 			.on('error', errorEvent)
 			.on('record', recordEvent);
 	});
@@ -108,7 +105,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 	}
 
 	function recordEvent(payload) {
-		// Console.log('debug', 'Record failed: ' + payload.failed);
+		console.log('debug', 'Record failed: ' + payload.failed);
 		if (payload.failed) {
 			failedRecordsArray.push(payload);
 		} else {

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -66,7 +66,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 
 	await new Promise(resolve => {
 		TransformClient
-			.on('end', resolve())
+			.on('end', () => resolve())
 			.on('error', errorEvent)
 			.on('record', recordEvent);
 	});

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -108,12 +108,12 @@ export default async ({name, yargsOptions = [], callback}) => {
 		counter = amount;
 	}
 
-	function logEvent(logs) {
-		console.log(logs);
+	function logEvent(log) {
+		console.log(log);
 	}
 
 	function recordEvent(payload) {
-		// Console.log('debug', 'Record failed: ' + payload.failed);
+		console.log('debug', 'Record failed: ' + payload.failed);
 		if (payload.failed) {
 			failedRecordsArray.push(payload);
 		} else {

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -66,7 +66,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 
 	await new Promise(resolve => {
 		TransformClient
-			.on('end', resolve)
+			.on('end', resolve())
 			.on('error', errorEvent)
 			.on('record', recordEvent);
 	});

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -61,10 +61,10 @@ export default async ({name, yargsOptions = [], callback}) => {
 	const spinner = ora(`Transforming${args.validate ? ' and validating' : ''}${args.fix ? ' and fixing' : ''} records`).start();
 
 	const stream = fs.createReadStream(args.file);
+	const TransformEmitter = callback(stream, args);
+	const pendingPromises = [];
 
 	await new Promise((resolve, reject) => {
-		const TransformEmitter = callback(stream, args);
-		const pendingPromises = [];
 		let counter = 0;
 
 		TransformEmitter

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -66,7 +66,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 
 	await new Promise(resolve => {
 		TransformClient
-			.on('end', () => resolve(true))
+			.on('end', resolve())
 			.on('error', errorEvent)
 			.on('record', recordEvent);
 	});

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -66,7 +66,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 
 	await new Promise(resolve => {
 		TransformClient
-			.on('end', () => resolve())
+			.on('end', () => resolve(true))
 			.on('error', errorEvent)
 			.on('record', recordEvent);
 	});

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -63,9 +63,12 @@ export default async ({name, yargsOptions = [], callback}) => {
 	const TransformClient = callback(options);
 	let succesRecordArray = [];
 	let failedRecordsArray = [];
+	let counter = -1;
+	let numberOfRecords = 0;
 
 	await new Promise(resolve => {
 		TransformClient
+			.on('counter', counterEvent)
 			.on('end', () => {
 				console.log('debug', 'ending');
 				resolve(true);
@@ -103,6 +106,10 @@ export default async ({name, yargsOptions = [], callback}) => {
 		}
 	}
 
+	function counterEvent(amount) {
+		counter = amount;
+	}
+
 	function errorEvent(err) {
 		console.log('error', err);
 	}
@@ -113,6 +120,11 @@ export default async ({name, yargsOptions = [], callback}) => {
 			failedRecordsArray.push(payload);
 		} else {
 			succesRecordArray.push(payload);
+		}
+
+		numberOfRecords++;
+		if (numberOfRecords === counter) {
+			TransformClient.emit('end');
 		}
 	}
 };

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -105,7 +105,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 	}
 
 	function recordEvent(payload) {
-		console.log('debug', 'Record failed: ' + payload.failed);
+		// Console.log('debug', 'Record failed: ' + payload.failed);
 		if (payload.failed) {
 			failedRecordsArray.push(payload);
 		} else {

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -65,7 +65,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 		args
 	};
 
-	logger.log('debug', args);
+	console.log('debug', args);
 	await new Promise((resolve, reject) => {
 		const TransformEmitter = callback(options);
 		const pendingPromises = [];

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -60,14 +60,11 @@ export default async ({name, yargsOptions = [], callback}) => {
 
 	const spinner = ora(`Transforming${args.validate ? ' and validating' : ''}${args.fix ? ' and fixing' : ''} records`).start();
 
-	const options = {
-		stream: fs.createReadStream(args.file),
-		args
-	};
+	const stream =fs.createReadStream(args.file);
 
 	console.log('debug', args);
 	await new Promise((resolve, reject) => {
-		const TransformEmitter = callback(options);
+		const TransformEmitter = callback(spinner, args);
 		const pendingPromises = [];
 		let counter = 0;
 

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -122,6 +122,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 
 		numberOfRecords++;
 		if (numberOfRecords === counter) {
+			TransformClient.emit('log', 'ending');
 			TransformClient.emit('end');
 		}
 	}

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -69,10 +69,8 @@ export default async ({name, yargsOptions = [], callback}) => {
 	await new Promise(resolve => {
 		TransformClient
 			.on('counter', counterEvent)
-			.on('end', () => {
-				console.log('debug', 'ending');
-				resolve(true);
-			})
+			.on('end', () => resolve(true))
+			.on('log', logEvent)
 			.on('error', errorEvent)
 			.on('record', recordEvent);
 	});
@@ -104,6 +102,10 @@ export default async ({name, yargsOptions = [], callback}) => {
 		} else {
 			console.log(JSON.stringify(records.map(r => r.record), undefined, 2));
 		}
+	}
+
+	function logEvent(log) {
+		console.log(log);
 	}
 
 	function counterEvent(amount) {

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -63,14 +63,10 @@ export default async ({name, yargsOptions = [], callback}) => {
 	const TransformClient = callback(options);
 	let succesRecordArray = [];
 	let failedRecordsArray = [];
-	let counter = -1;
-	let numberOfRecords = 0;
 
 	await new Promise(resolve => {
 		TransformClient
-			.on('counter', counterEvent)
 			.on('end', () => resolve(true))
-			.on('log', logEvent)
 			.on('error', errorEvent)
 			.on('record', recordEvent);
 	});
@@ -104,15 +100,6 @@ export default async ({name, yargsOptions = [], callback}) => {
 		}
 	}
 
-	function logEvent(log) {
-		console.log(log);
-	}
-
-	function counterEvent(amount) {
-		console.log('counter event');
-		counter = amount;
-	}
-
 	function errorEvent(err) {
 		console.log('error', err);
 	}
@@ -123,11 +110,6 @@ export default async ({name, yargsOptions = [], callback}) => {
 			failedRecordsArray.push(payload);
 		} else {
 			succesRecordArray.push(payload);
-		}
-
-		numberOfRecords++;
-		if (numberOfRecords === counter) {
-			TransformClient.emit('end');
 		}
 	}
 };

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -60,11 +60,10 @@ export default async ({name, yargsOptions = [], callback}) => {
 		args
 	};
 
-	let counter = 0;
-
 	await new Promise((resolve, reject) => {
 		const TransformEmitter = callback(options);
 		const pendingPromises = [];
+		let counter = 0;
 
 		TransformEmitter
 			.on('end', async () => {
@@ -91,22 +90,22 @@ export default async ({name, yargsOptions = [], callback}) => {
 						handleOutput(payload.record);
 					}
 				}
+
+				function handleOutput(record) {
+					if (args.outputDirectory) {
+						if (!fs.existsSync(args.outputDirectory)) {
+							fs.mkdirSync(args.outputDirectory);
+						}
+
+						const file = path.join(args.outputDirectory, `${counter}.json`);
+						counter++;
+						fs.writeFileSync(file, JSON.stringify(record, undefined, 2));
+					} else {
+						console.log(JSON.stringify(record.map(record), undefined, 2));
+					}
+				}
 			});
 	});
 
 	spinner.succeed();
-
-	function handleOutput(record) {
-		if (args.outputDirectory) {
-			if (!fs.existsSync(args.outputDirectory)) {
-				fs.mkdirSync(args.outputDirectory);
-			}
-
-			const file = path.join(args.outputDirectory, `${counter}.json`);
-			fs.writeFileSync(file, JSON.stringify(record, undefined, 2));
-			counter++;
-		} else {
-			console.log(JSON.stringify(record.map(record), undefined, 2));
-		}
-	}
 };

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -107,6 +107,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 	}
 
 	function counterEvent(amount) {
+		console.log('counter event');
 		counter = amount;
 	}
 

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -80,7 +80,6 @@ export default async ({name, yargsOptions = [], callback}) => {
 
 				async function recordEvent(payload) {
 					// Console.log('debug', 'Record failed: ' + payload.failed);
-					await Promise.all(payload);
 					if (payload.failed) {
 						if (!args.recordsOnly) {
 							// Send record to be handled

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -107,17 +107,16 @@ export default async ({name, yargsOptions = [], callback}) => {
 		console.log('debug', `Expecting ${amount} records`);
 		counter = amount;
 		if (numberOfRecords === counter) {
-			TransformClient.emit('log', 'ending');
 			TransformClient.emit('end');
 		}
 	}
 
 	function logEvent(log) {
-		console.log(log);
+		console.log('debug', log);
 	}
 
 	function recordEvent(payload) {
-		console.log('debug', 'Record failed: ' + payload.failed);
+		// Console.log('debug', 'Record failed: ' + payload.failed);
 		if (payload.failed) {
 			failedRecordsArray.push(payload);
 		} else {
@@ -126,7 +125,6 @@ export default async ({name, yargsOptions = [], callback}) => {
 
 		numberOfRecords++;
 		if (numberOfRecords === counter) {
-			TransformClient.emit('log', 'ending');
 			TransformClient.emit('end');
 		}
 	}

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -106,6 +106,10 @@ export default async ({name, yargsOptions = [], callback}) => {
 	function setCounter(amount) {
 		console.log('debug', `Expecting ${amount} records`);
 		counter = amount;
+		if (numberOfRecords === counter) {
+			TransformClient.emit('log', 'ending');
+			TransformClient.emit('end');
+		}
 	}
 
 	function logEvent(log) {

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -63,11 +63,14 @@ export default async ({name, yargsOptions = [], callback}) => {
 	const TransformClient = callback(options);
 	let succesRecordArray = [];
 	let failedRecordsArray = [];
+	let counter = -1;
+	let numberOfRecords = 0;
 
 	await new Promise(resolve => {
 		TransformClient
 			.on('end', () => resolve(true))
 			.on('log', logEvent)
+			.on('counter', setCounter)
 			.on('record', recordEvent);
 	});
 
@@ -100,6 +103,11 @@ export default async ({name, yargsOptions = [], callback}) => {
 		}
 	}
 
+	function setCounter(amount) {
+		console.log('debug', `Expecting ${amount} records`);
+		counter = amount;
+	}
+
 	function logEvent(logs) {
 		console.log(logs);
 	}
@@ -110,6 +118,11 @@ export default async ({name, yargsOptions = [], callback}) => {
 			failedRecordsArray.push(payload);
 		} else {
 			succesRecordArray.push(payload);
+		}
+
+		numberOfRecords++;
+		if (numberOfRecords === counter) {
+			TransformClient.emit('end');
 		}
 	}
 };

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -101,7 +101,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 						counter++;
 						fs.writeFileSync(file, JSON.stringify(record, undefined, 2));
 					} else {
-						console.log(JSON.stringify(record.map(record), undefined, 2));
+						console.log(JSON.stringify(record, undefined, 2));
 					}
 				}
 			});

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -67,7 +67,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 	await new Promise(resolve => {
 		TransformClient
 			.on('end', () => {
-				console.log('info', 'ending');
+				console.log('debug', 'ending');
 				resolve(true);
 			})
 			.on('error', errorEvent)
@@ -108,7 +108,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 	}
 
 	function recordEvent(payload) {
-		// Console.log('debug', 'Record failed: ' + payload.failed);
+		console.log('debug', 'Record failed: ' + payload.failed);
 		if (payload.failed) {
 			failedRecordsArray.push(payload);
 		} else {

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -65,8 +65,8 @@ export default async ({name, yargsOptions = [], callback}) => {
 		args
 	};
 
+	logger.log('debug', args);
 	await new Promise((resolve, reject) => {
-		logger.log('debug', args);
 		const TransformEmitter = callback(options);
 		const pendingPromises = [];
 		let counter = 0;

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -74,7 +74,7 @@ export default async ({name, yargsOptions = [], callback}) => {
 				resolve();
 			})
 			.on('error', err => {
-				console.log('error', err);
+				logger.log('error', err);
 				reject(err);
 			})
 			.on('record', async payload => {

--- a/src/transformer/cli.js
+++ b/src/transformer/cli.js
@@ -63,14 +63,11 @@ export default async ({name, yargsOptions = [], callback}) => {
 	const TransformClient = callback(options);
 	let succesRecordArray = [];
 	let failedRecordsArray = [];
-	let counter = -1;
-	let numberOfRecords = 0;
 
 	await new Promise(resolve => {
 		TransformClient
-			.on('end', () => resolve(true))
-			.on('log', logEvent)
-			.on('counter', setCounter)
+			.on('end', resolve)
+			.on('error', errorEvent)
 			.on('record', recordEvent);
 	});
 
@@ -103,16 +100,8 @@ export default async ({name, yargsOptions = [], callback}) => {
 		}
 	}
 
-	function setCounter(amount) {
-		console.log('debug', `Expecting ${amount} records`);
-		counter = amount;
-		if (numberOfRecords === counter) {
-			TransformClient.emit('end');
-		}
-	}
-
-	function logEvent(log) {
-		console.log('debug', log);
+	function errorEvent(err) {
+		console.log('error', err);
 	}
 
 	function recordEvent(payload) {
@@ -121,11 +110,6 @@ export default async ({name, yargsOptions = [], callback}) => {
 			failedRecordsArray.push(payload);
 		} else {
 			succesRecordArray.push(payload);
-		}
-
-		numberOfRecords++;
-		if (numberOfRecords === counter) {
-			TransformClient.emit('end');
 		}
 	}
 };

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -97,7 +97,6 @@ export default async function (transformCallback) {
 				await ApiClient.setTransformationDone({id: BLOB_ID, numberOfRecords});
 			}
 
-
 			function setCounter(amount) {
 				logger.log('debug', `counter is set to ${amount}`);
 				counter = amount;
@@ -110,7 +109,7 @@ export default async function (transformCallback) {
 			async function recordEvent(payload) {
 				logger.log('debug', 'Record failed: ' + payload.failed);
 				payload.timeStamp = moment();
-				
+
 				if (payload.failed) {
 					hasFailed = true;
 					pendingPromises.push(

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -68,7 +68,7 @@ export default async function (transformCallback) {
 		try {
 			connection = await amqplib.connect(AMQP_URL);
 			channel = await connection.createChannel();
-			const TransformEmitter = transformCallback(readStream);
+			const TransformEmitter = transformCallback(readStream, {});
 			let hasFailed = false;
 			const pendingPromises = [];
 
@@ -114,7 +114,6 @@ export default async function (transformCallback) {
 
 						async function updateBlob(payload) {
 							await Promise.all(payload);
-							console.log(payload);
 							try {
 								if (payload.failed) {
 									hasFailed = true;

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -113,6 +113,10 @@ export default async function (transformCallback) {
 		function setCounter(amount) {
 			logger.log('debug', `counter is set to ${amount}`);
 			counter = amount;
+			if (numberOfRecords === counter) {
+				logger.log('info', `Beginning end process. Handled records ${numberOfRecords}/${counter}`);
+				TransformClient.emit('end');
+			}
 		}
 
 		function logEvent(message) {

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -89,9 +89,9 @@ export default async function (transformCallback) {
 
 						resolve(true);
 					})
-					.on('error', err => {
+					.on('error', async err => {
 						logger.log('info', 'Transformation failed');
-						ApiClient.setTransformationFailed({id: BLOB_ID, error: err});
+						await ApiClient.setTransformationFailed({id: BLOB_ID, error: err});
 						reject(err);
 					})
 					.on('record', async payload => {

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -100,7 +100,6 @@ export default async function (transformCallback) {
 						pendingPromises.push(updateBlob(payload));
 
 						async function sendRecordToQueue(payload) {
-							await Promise.all(payload);
 							if ((!ABORT_ON_INVALID_RECORDS || (ABORT_ON_INVALID_RECORDS && !hasFailed))) {
 								try {
 									channel.assertQueue(BLOB_ID, {durable: true});
@@ -113,7 +112,6 @@ export default async function (transformCallback) {
 						}
 
 						async function updateBlob(payload) {
-							await Promise.all(payload);
 							try {
 								if (payload.failed) {
 									hasFailed = true;

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -96,7 +96,8 @@ export default async function (transformCallback) {
 					})
 					.on('record', async payload => {
 						payload.timeStamp = moment();
-						logger.log('debug', `payload: ${JSON.stringify(payload)}`);
+						logger.log('debug', `payload: ${payload.failed}`);
+						logger.log('debug', `payload: ${payload.record}`);
 						pendingPromises.push(sendRecordToQueue(payload));
 						pendingPromises.push(updateBlob(payload));
 

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -129,7 +129,7 @@ export default async function (transformCallback) {
 				await ApiClient.setTransformationFailed({id: BLOB_ID, error: {message: 'Some records have failed'}});
 			} else {
 				logger.log('info', `Setting blob state ${BLOB_STATE.TRANSFORMED}¸¸`);
-				await ApiClient.setTransformationDone({id: BLOB_ID});
+				await ApiClient.updateState({id: BLOB_ID, state: BLOB_STATE.TRANSFORMED});
 			}
 		} catch (err) {
 			logger.log('error', `Failed transforming blob: ${err.stack}`);

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -96,8 +96,6 @@ export default async function (transformCallback) {
 					})
 					.on('record', async payload => {
 						payload.timeStamp = moment();
-						logger.log('debug', `payload: ${payload.failed}`);
-						logger.log('debug', `payload: ${payload.record}`);
 						pendingPromises.push(sendRecordToQueue(payload));
 						pendingPromises.push(updateBlob(payload));
 

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -73,13 +73,17 @@ export default async function (transformCallback) {
 			channel = await connection.createChannel();
 			TransformClient = transformCallback(readStream);
 
-			await new Promise((resolve, reject) => {
+			await new Promise(resolve => {
 				TransformClient
 					.on('end', async () => {
+						console.log(pendingPromises.length);
 						await Promise.all(pendingPromises);
+						console.log(pendingPromises.length);
 						resolve();
 					})
-					.on('error', () => reject)
+					.on('error', err => {
+						console.log('error', `Transformer error: ${err instanceof Error ? err.stack : err}`);
+					})
 					.on('record', async payload => {
 						pendingPromises.push(recordEvent(payload));
 

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -100,6 +100,7 @@ export default async function (transformCallback) {
 						pendingPromises.push(updateBlob(payload));
 
 						async function sendRecordToQueue(payload) {
+							await Promise.all(payload);
 							if ((!ABORT_ON_INVALID_RECORDS || (ABORT_ON_INVALID_RECORDS && !hasFailed))) {
 								try {
 									channel.assertQueue(BLOB_ID, {durable: true});
@@ -112,6 +113,8 @@ export default async function (transformCallback) {
 						}
 
 						async function updateBlob(payload) {
+							await Promise.all(payload);
+							console.log(payload);
 							try {
 								if (payload.failed) {
 									hasFailed = true;

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -67,9 +67,9 @@ export default async function (transformCallback) {
 		const ApiClient = createApiClient({url: API_URL, username: API_USERNAME, password: API_PASSWORD, userAgent: API_CLIENT_USER_AGENT});
 		const {readStream} = await ApiClient.getBlobContent({id: BLOB_ID});
 		let TransformClient;
-		
+
 		logger.log('info', `Starting transformation for blob ${BLOB_ID}`);
-		
+
 		try {
 			connection = await amqplib.connect(AMQP_URL);
 			channel = await connection.createChannel();

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -62,6 +62,7 @@ export default async function (transformCallback) {
 		let hasFailed = false;
 		const pendingPromises = [];
 		let numberOfRecords;
+		let sentRecords = 0;
 
 		const ApiClient = createApiClient({url: API_URL, username: API_USERNAME, password: API_PASSWORD, userAgent: API_CLIENT_USER_AGENT});
 		const {readStream} = await ApiClient.getBlobContent({id: BLOB_ID});
@@ -78,10 +79,13 @@ export default async function (transformCallback) {
 				TransformClient
 					.on('end', count => {
 						numberOfRecords = count;
-						resolve(Promise.all(pendingPromises));
+						if (numberOfRecords === sentRecords) {
+							TransformClient.emit('resolve');
+						}
 					})
 					.on('error', () => reject)
-					.on('record', recordEvent);
+					.on('record', recordEvent)
+					.on('resolve', resolve(Promise.all(pendingPromises)));
 			});
 
 			logger.log('info', 'Transformation done');
@@ -118,11 +122,18 @@ export default async function (transformCallback) {
 						record: payload.record
 					})
 				);
-			} else if ((!ABORT_ON_INVALID_RECORDS || (ABORT_ON_INVALID_RECORDS && !hasFailed))) {
+			}
+
+			if ((!ABORT_ON_INVALID_RECORDS || (ABORT_ON_INVALID_RECORDS && !hasFailed))) {
 				await channel.assertQueue(BLOB_ID, {durable: true});
 				const message = Buffer.from(JSON.stringify(payload.record));
 				pendingPromises.push(channel.sendToQueue(BLOB_ID, message, {persistent: true, messageId: uuid()}));
 				logger.log('debug', `Record sent to queue as profile: ${PROFILE_ID}`);
+			}
+
+			sentRecords++;
+			if (numberOfRecords && sentRecords === numberOfRecords) {
+				TransformClient.emit('resolve');
 			}
 		}
 	}

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -66,13 +66,14 @@ export default async function (transformCallback) {
 
 		const ApiClient = createApiClient({url: API_URL, username: API_USERNAME, password: API_PASSWORD, userAgent: API_CLIENT_USER_AGENT});
 		const {readStream} = await ApiClient.getBlobContent({id: BLOB_ID});
-		const TransformClient = transformCallback(readStream);
-
+		let TransformClient;
+		
 		logger.log('info', `Starting transformation for blob ${BLOB_ID}`);
-
+		
 		try {
 			connection = await amqplib.connect(AMQP_URL);
 			channel = await connection.createChannel();
+			TransformClient = transformCallback(readStream);
 
 			try {
 				await new Promise((resolve, reject) => {

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -75,7 +75,7 @@ export default async function (transformCallback) {
 
 			const result = await new Promise((resolve, reject) => {
 				TransformClient
-					.on('end', async count => {
+					.on('end', async (count = 0) => {
 						logger.log('debug', `Transformer has handled ${pendingPromises.length / 2} / ${count} record promises to line`);
 						await Promise.all(pendingPromises);
 						logger.log('debug', `Transforming is done (${pendingPromises.length / 2} / ${count})`);
@@ -121,6 +121,8 @@ export default async function (transformCallback) {
 						}
 					});
 			});
+
+			logger.log('debug', result);
 
 			if (result.state === 'fulfilled') {
 				logger.log('info', 'Transformation done');

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -96,6 +96,7 @@ export default async function (transformCallback) {
 					})
 					.on('record', async payload => {
 						payload.timeStamp = moment();
+						logger.log('debug', `payload: ${payload}`);
 						pendingPromises.push(sendRecordToQueue(payload));
 						pendingPromises.push(updateBlob(payload));
 

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -96,7 +96,7 @@ export default async function (transformCallback) {
 					})
 					.on('record', async payload => {
 						payload.timeStamp = moment();
-						logger.log('debug', `payload: ${payload}`);
+						logger.log('debug', `payload: ${JSON.stringify(payload)}`);
 						pendingPromises.push(sendRecordToQueue(payload));
 						pendingPromises.push(updateBlob(payload));
 

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -74,19 +74,15 @@ export default async function (transformCallback) {
 			channel = await connection.createChannel();
 			TransformClient = transformCallback(readStream);
 
-			try {
-				await new Promise((resolve, reject) => {
-					TransformClient
-						.on('end', count => {
-							numberOfRecords = count;
-							resolve(Promise.all(pendingPromises));
-						})
-						.on('error', () => reject)
-						.on('record', recordEvent);
-				});
-			} catch (err) {
-				logger.log('error', `Emitter promise error: ${err.stack}`);
-			}
+			await new Promise((resolve, reject) => {
+				TransformClient
+					.on('end', count => {
+						numberOfRecords = count;
+						resolve(Promise.all(pendingPromises));
+					})
+					.on('error', () => reject)
+					.on('record', recordEvent);
+			});
 
 			logger.log('info', 'Transformation done');
 

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -84,7 +84,7 @@ export default async function (transformCallback) {
 						pendingPromises.push(recordEvent(payload));
 
 						async function recordEvent(payload) {
-							logger.log('debug', 'Record failed: ' + payload.failed);
+							// Logger.log('debug', 'Record failed: ' + payload.failed);
 							payload.timeStamp = moment();
 
 							if (payload.failed) {
@@ -103,7 +103,7 @@ export default async function (transformCallback) {
 								channel.assertQueue(BLOB_ID, {durable: true});
 								const message = Buffer.from(JSON.stringify(payload.record));
 								await channel.sendToQueue(BLOB_ID, message, {persistent: true, messageId: uuid()});
-								logger.log('debug', `Record sent to queue as profile: ${PROFILE_ID}`);
+								// Logger.log('debug', `Record sent to queue as profile: ${PROFILE_ID}`);
 							}
 						}
 					});

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -34,7 +34,6 @@ import uuid from 'uuid/v4';
 import {Utils} from '@natlibfi/melinda-commons';
 import {registerSignalHandlers, startHealthCheckService} from '../common';
 import {createApiClient} from '../api-client';
-import moment from 'moment';
 import {BLOB_STATE} from '../constants';
 
 const {createLogger} = Utils;
@@ -95,11 +94,10 @@ export default async function (transformCallback) {
 						reject(err);
 					})
 					.on('record', async payload => {
-						payload.timeStamp = moment();
-						pendingPromises.push(sendRecordToQueue(payload));
-						pendingPromises.push(updateBlob(payload));
+						pendingPromises.push(sendRecordToQueue());
+						pendingPromises.push(updateBlob());
 
-						async function sendRecordToQueue(payload) {
+						async function sendRecordToQueue() {
 							if (!payload.failed) {
 								if ((!ABORT_ON_INVALID_RECORDS || (ABORT_ON_INVALID_RECORDS && !hasFailed))) {
 									try {
@@ -113,13 +111,13 @@ export default async function (transformCallback) {
 							}
 						}
 
-						async function updateBlob(payload) {
+						async function updateBlob() {
 							try {
 								if (payload.failed) {
 									hasFailed = true;
 									await ApiClient.transformedRecord({
 										id: BLOB_ID,
-										error: payload.record
+										error: payload
 									});
 								} else {
 									await ApiClient.transformedRecord({

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -85,7 +85,7 @@ export default async function (transformCallback) {
 					})
 					.on('error', () => reject)
 					.on('record', recordEvent)
-					.on('resolve', resolve(Promise.all(pendingPromises)));
+					.on('resolve', () => resolve(Promise.all(pendingPromises)));
 			});
 
 			logger.log('info', 'Transformation done');

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -95,7 +95,7 @@ export default async function (transformCallback) {
 				await ApiClient.setTransformationFailed({id: BLOB_ID, error: {message: 'Some records have failed'}});
 			} else {
 				logger.log('info', `Setting blob state ${BLOB_STATE.TRANSFORMED}¸¸`);
-				await ApiClient.setTransformationDone({id: BLOB_ID, numberOfRecords});
+				await ApiClient.setTransformationDone({id: BLOB_ID});
 			}
 		} catch (err) {
 			logger.log('error', `Failed transforming blob: ${err.stack}`);
@@ -117,9 +117,15 @@ export default async function (transformCallback) {
 			if (payload.failed) {
 				hasFailed = true;
 				pendingPromises.push(
-					ApiClient.transformedRecordFailed({
+					ApiClient.transformedRecord({
 						id: BLOB_ID,
 						record: payload.record
+					})
+				);
+			} else {
+				pendingPromises.push(
+					ApiClient.transformedRecord({
+						id: BLOB_ID
 					})
 				);
 			}

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -85,43 +85,38 @@ export default async function (transformCallback) {
 						console.log('error', `Transformer error: ${err instanceof Error ? err.stack : err}`);
 					})
 					.on('record', async payload => {
-						pendingPromises.push(recordEvent(payload));
+						payload.timeStamp = moment();
+						pendingPromises.push(sendRecodToQueue(payload));
+						pendingPromises.push(updateBlob(payload));
 
-						function recordEvent(payload) {
-							// Logger.log('debug', 'Record failed: ' + payload.failed);
-							payload.timeStamp = moment();
-
-							return Promise.all(sendRecodToQueue(channel, payload), updateBlob(payload));
-
-							async function sendRecodToQueue(payload) {
-								if ((!ABORT_ON_INVALID_RECORDS || (ABORT_ON_INVALID_RECORDS && !hasFailed))) {
-									try {
-										channel.assertQueue(BLOB_ID, {durable: true});
-										const message = Buffer.from(JSON.stringify(payload.record));
-										await channel.sendToQueue(BLOB_ID, message, {persistent: true, messageId: uuid()});
-									} catch (err) {
-										logger.log('error', `Error while sending record to queue: ${err instanceof Error ? err.stack : err}`);
-									}
-									// Logger.log('debug', `Record sent to queue as profile: ${PROFILE_ID}`);
-								}
-							}
-
-							async function updateBlob(payload) {
+						async function sendRecodToQueue(payload) {
+							if ((!ABORT_ON_INVALID_RECORDS || (ABORT_ON_INVALID_RECORDS && !hasFailed))) {
 								try {
-									if (payload.failed) {
-										hasFailed = true;
-										await ApiClient.transformedRecord({
-											id: BLOB_ID,
-											record: payload.record
-										});
-									} else {
-										await ApiClient.transformedRecord({
-											id: BLOB_ID
-										});
-									}
+									channel.assertQueue(BLOB_ID, {durable: true});
+									const message = Buffer.from(JSON.stringify(payload.record));
+									await channel.sendToQueue(BLOB_ID, message, {persistent: true, messageId: uuid()});
 								} catch (err) {
-									logger.log('error', `Error while updating blob: ${err instanceof Error ? err.stack : err}`);
+									logger.log('error', `Error while sending record to queue: ${err instanceof Error ? err.stack : err}`);
 								}
+								// Logger.log('debug', `Record sent to queue as profile: ${PROFILE_ID}`);
+							}
+						}
+
+						async function updateBlob(payload) {
+							try {
+								if (payload.failed) {
+									hasFailed = true;
+									await ApiClient.transformedRecord({
+										id: BLOB_ID,
+										record: payload.record
+									});
+								} else {
+									await ApiClient.transformedRecord({
+										id: BLOB_ID
+									});
+								}
+							} catch (err) {
+								logger.log('error', `Error while updating blob: ${err instanceof Error ? err.stack : err}`);
 							}
 						}
 					});

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -125,10 +125,12 @@ export default async function (transformCallback) {
 			}
 
 			if ((!ABORT_ON_INVALID_RECORDS || (ABORT_ON_INVALID_RECORDS && !hasFailed))) {
-				await channel.assertQueue(BLOB_ID, {durable: true});
-				const message = Buffer.from(JSON.stringify(payload.record));
 				pendingPromises.push(
-					Promise.resolve(channel.sendToQueue(BLOB_ID, message, {persistent: true, messageId: uuid()}))
+					new Promise(resolve => {
+						channel.assertQueue(BLOB_ID, {durable: true});
+						const message = Buffer.from(JSON.stringify(payload.record));
+						resolve(channel.sendToQueue(BLOB_ID, message, {persistent: true, messageId: uuid()}));
+					})
 						.then(() => {
 							logger.log('debug', `Record sent to queue as profile: ${PROFILE_ID}`);
 							recordSent();

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -123,7 +123,6 @@ export default async function (transformCallback) {
 			});
 
 			if (result === true) {
-				logger.log('info', 'Transformation done');
 				if (ABORT_ON_INVALID_RECORDS && hasFailed) {
 					logger.log('info', 'Not sending records to queue because some records failed and ABORT_ON_INVALID_RECORDS is true');
 					await ApiClient.setTransformationFailed({id: BLOB_ID, error: {message: 'Some records have failed'}});


### PR DESCRIPTION
### Updated
Loggings,
Takes Emitter from transformer and accepts single records.
Handles single record to import queue or blobs failedRecords array.

### Local test settings:
- melinda-record-import-api #melhehitys-1020 build locally
- melinda-record-import-controller #melkehitys-1020 build locally
- melinda-record-import-importer-dummy #melkehitys-1023 build locally
- melinda-record-import-transformer-helmet #melkehitys-1020 build locally
and melinda-record-import-transformer-dummy #melkehitys-1023